### PR TITLE
Fix docker hub builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 *
-!/src
+!src
 !pom.xml
-!/fhir-pgdata
+!fhir-pgdata


### PR DESCRIPTION
Fix the Docker Hub builds by removing the leading slashes from folder unignore statements in `.dockerignore`.

See a successful build here: https://hub.docker.com/repository/registry-1.docker.io/infernocommunity/inferno-reference-server/builds/1a0d9c0d-b051-4490-ab6a-ddb61cba5251