### PR TITLE
Add Patient Name Absent message if no name in picker.

### DIFF
--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -56,6 +56,10 @@ window.mitre.fhirreferenceserver.authorize = {
                 let familyName = patient.resource.name[0].family || "";
                 let name = givenName + " " + familyName;
                 name = name.trim();
+
+                if (name.length === 0){
+                    name = "&lt; <em>Patient Name Absent</em> &gt;"
+                }
                 
                                             
                 patientsTable.row.add( [


### PR DESCRIPTION
Having a blank line in there was confusing, added placeholder text:

![Screen Shot 2020-04-14 at 4 32 42 PM](https://user-images.githubusercontent.com/412901/79271347-aac82580-7e6d-11ea-8704-e507e1709eb7.png)
