### PR TITLE
Make root url reference server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This is a FHIR reference implementation server supporting the US Core R4 IG and SMART Launches.
 
 By default, you can browse the server at
-[http://localhost:8080](http://localhost:8080), and the FHIR endpoint is at
-[http://localhost:8080/r4](http://localhost:8080/r4)
+[http://localhost:8080](http://localhost:8080/reference-server), and the FHIR endpoint is at
+[http://localhost:8080/r4](http://localhost:8080/reference-server/r4)
 
 ## Running with Docker
 
@@ -41,7 +41,7 @@ To use as a confidential client, use `SAMPLE_CONFIDENTIAL_CLIENT_ID` as the clie
 
 The Authorization Bearer token can be used directly by setting the `Authorization` header to `Bearer SAMPLE_ACCESS_TOKEN.<SCOPES_ENCODED_IN_BASE_64>`. For example, a token with the `patient/*.*` scope should be set to `Bearer SAMPLE_ACCESS_TOKEN.cGF0aWVudC8qLio=`.  Note that as this server is primarily for demo, this token is not secure.
 
-To launch an app from the EHR go to `reference-server/app-launch` 
+To launch an app from the EHR go to `reference-server/app/app-launch` 
 
 ## Contact Us
 The Inferno development team can be reached by email at inferno@groups.mitre.org. Inferno also has a dedicated [HL7 FHIR chat channel](https://chat.fhir.org/#narrow/stream/153-inferno).

--- a/src/main/java/org/mitre/fhir/authorization/ServerConformanceWithAuthorizationProvider.java
+++ b/src/main/java/org/mitre/fhir/authorization/ServerConformanceWithAuthorizationProvider.java
@@ -12,7 +12,7 @@ import org.hl7.fhir.r4.model.Enumerations.SearchParamType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.UriType;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.mitre.fhir.utils.FhirReferenceServerUtils;
 
 import ca.uhn.fhir.jpa.dao.DaoConfig;
 import ca.uhn.fhir.jpa.dao.IFhirSystemDao;
@@ -92,18 +92,11 @@ public class ServerConformanceWithAuthorizationProvider extends JpaConformancePr
 	
 	public static String getTokenExtensionURI(HttpServletRequest theRequest)
 	{
-		return getBaseURL(theRequest) + theRequest.getContextPath() + TOKEN_EXTENSION_VALUE_URI;
+		return FhirReferenceServerUtils.getServerBaseUrl(theRequest) + TOKEN_EXTENSION_VALUE_URI;
 	}
 	
 	public static String getAuthorizationExtensionURI(HttpServletRequest theRequest)
 	{
-		return getBaseURL(theRequest) + theRequest.getContextPath() + AUTHORIZE_EXTENSION_VALUE_URI;
+		return FhirReferenceServerUtils.getServerBaseUrl(theRequest) + AUTHORIZE_EXTENSION_VALUE_URI;
 	}
-	
-	private static String getBaseURL(HttpServletRequest theRequest)
-	{
-		String baseUrl = ServletUriComponentsBuilder.fromRequestUri(theRequest).replacePath(null).build().toUriString();
-		return baseUrl;
-	}
-
 }

--- a/src/main/java/org/mitre/fhir/authorization/exception/InvalidClientIdException.java
+++ b/src/main/java/org/mitre/fhir/authorization/exception/InvalidClientIdException.java
@@ -10,6 +10,6 @@ public class InvalidClientIdException extends ResponseStatusException {
 	private static final long serialVersionUID = 1L;
 
 	public InvalidClientIdException(String clientId) {
-		super(HttpStatus.UNAUTHORIZED, ERROR_MESSAGE + " Supplied Client ID: " + clientId);
+		super(HttpStatus.UNAUTHORIZED, ERROR_MESSAGE + " Supplied Client ID: \"" + clientId + "\"");
 	}
 }

--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -21,11 +21,26 @@ public class FhirReferenceServerUtils {
 	public static final String SAMPLE_CONFIDENTIAL_CLIENT_SECRET = "SAMPLE_CONFIDENTIAL_CLIENT_SECRET";
 	
 	public static final String DEFAULT_SCOPE = "launch/patient patient/*";
+	
+	private static final String HTTP = "http";
+	private static final String HTTPS = "https";
+	private static final int HTTP_DEFAULT_PORT = 80;
+	private static final int HTTPS_DEFAULT_PORT = 443;
 
 
 
 	public static String getServerBaseUrl(HttpServletRequest request) {
-		String serverBaseUrl = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + "/reference-server";
+		String scheme = request.getScheme();
+		int portNumber = request.getServerPort();
+		String port = ":" + portNumber;
+		
+		//if default port, remove the port
+		if ((HTTP.equals(scheme) && portNumber == HTTP_DEFAULT_PORT) || (HTTPS.equals(scheme) && portNumber == HTTPS_DEFAULT_PORT))
+		{
+			port = "";
+		}
+		
+		String serverBaseUrl = request.getScheme() + "://" + request.getServerName() + port + "/reference-server";
 		return serverBaseUrl;
 	}
 

--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -14,7 +14,7 @@ public class FhirReferenceServerUtils {
 	public static final String AUTHORIZATION_HEADER_VALUE = "Bearer " + SAMPLE_ACCESS_TOKEN;
 	public static final String BEARER_TOKEN_PREFIX = "Bearer";
 	public static final String FHIR_SERVER_PATH = "/r4";
-	public static final String REFERENCE_SERVER_PATH = "/reference-server";
+	public static final String REFERENCE_SERVER_PATH = "/app";
 
 	public static final String SAMPLE_PUBLIC_CLIENT_ID = "SAMPLE_PUBLIC_CLIENT_ID";
 	public static final String SAMPLE_CONFIDENTIAL_CLIENT_ID = "SAMPLE_CONFIDENTIAL_CLIENT_ID";
@@ -25,7 +25,7 @@ public class FhirReferenceServerUtils {
 
 
 	public static String getServerBaseUrl(HttpServletRequest request) {
-		String serverBaseUrl = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort();
+		String serverBaseUrl = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + "/reference-server";
 		return serverBaseUrl;
 	}
 

--- a/src/main/webapp/WEB-INF/templates/app-launch.html
+++ b/src/main/webapp/WEB-INF/templates/app-launch.html
@@ -20,7 +20,7 @@
 
 
       	$('#launchAppButton').click(function() {
-      		const url = '/reference-server/fhir-server-path'
+      		const url = '/reference-server/app/fhir-server-path'
 	        $.get(url, function(data, status) {
 	            let issParam = encodeURIComponent(data);
 	            let launchParam = "123"; //for now just static, but should be communicated back to fhir reference server and stored http://www.hl7.org/fhir/smart-app-launch/

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,7 @@
 
     <servlet-mapping>
         <servlet-name>fhirServlet</servlet-name>
-        <url-pattern>/r4/*</url-pattern>
+        <url-pattern>/reference-server/r4/*</url-pattern>
     </servlet-mapping>
 
     <!-- Tester Overlay Servlet -->
@@ -44,7 +44,7 @@
 
     <servlet-mapping>
         <servlet-name>spring</servlet-name>
-        <url-pattern>/reference-server/*</url-pattern>
+        <url-pattern>/reference-server/app/*</url-pattern>
     </servlet-mapping>
 
     <servlet>
@@ -64,7 +64,7 @@
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>wellknown</servlet-name>
-		<url-pattern>/r4/.well-known/*</url-pattern>
+		<url-pattern>/reference-server/r4/.well-known/*</url-pattern>
 	</servlet-mapping>
 	
 	<servlet>	
@@ -85,7 +85,7 @@
 	</servlet>
 	<servlet-mapping>
 		<servlet-name>authorization</servlet-name>
-		<url-pattern>/oauth/*</url-pattern>
+		<url-pattern>/reference-server/oauth/*</url-pattern>
 	</servlet-mapping>
 
     <!-- This filters provide support for Cross Origin Resource Sharing (CORS) -->

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -26,7 +26,7 @@ window.mitre.fhirreferenceserver.authorize = {
         //http://localhost:8080/hapi-fhir-jpaserver/oauth/authorization?response_type=code&client_id=&redirect_uri=http%3A%2F%2Flocalhost%3A4567%2Finferno%2Foauth2%2Fstatic%2Fredirect&scope=launch%2Fpatient+patient%2F%2A.read+openid+fhirUser+offline_access&state=ddc2657d-7146-418b-8b4e-64e3f8e92eb0&aud=http%3A%2F%2Flocalhost%3A8080%2Fhapi-fhir-jpaserver%2Ffhir
 
 
-        const url = '/oauth/authorizeClientId/' + clientId;
+        const url = 'authorizeClientId/' + clientId;
         $.get(url, function(data, status) {
         
             //populate patient picker with data

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -631,7 +631,7 @@ public class TestAuthorization {
 
 		ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
 		ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
-		ourServerBase = "http://localhost:" + ourPort + "/r4/";
+		ourServerBase = "http://localhost:" + ourPort + "/reference-server/r4/";
 
 		ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
 		ourClient.registerInterceptor(new LoggingInterceptor(true));

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
@@ -140,7 +140,7 @@ public class TestAuthorizationWithNoData {
 
 		ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
 		ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
-		ourServerBase = "http://localhost:" + ourPort + "/r4/";
+		ourServerBase = "http://localhost:" + ourPort + "/reference-server/r4/";
 
 		ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
 		ourClient.registerInterceptor(new LoggingInterceptor(true));

--- a/src/test/java/org/mitre/fhir/authorization/TestFhirReferenceServerUtils.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestFhirReferenceServerUtils.java
@@ -19,7 +19,7 @@ public class TestFhirReferenceServerUtils {
 		mockHttpServletRequest.setRequestURI("/.well-known/smart-configuration");
 		
 		String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockHttpServletRequest);
-		Assert.assertEquals("http://www.example.org:123", baseUrl);
+		Assert.assertEquals("http://www.example.org:123/reference-server", baseUrl);
 	}
 	
 	@Test
@@ -33,7 +33,7 @@ public class TestFhirReferenceServerUtils {
 		mockHttpServletRequest.setRequestURI("/.well-known/smart-configuration");
 		
 		String baseUrl = FhirReferenceServerUtils.getFhirServerBaseUrl(mockHttpServletRequest);
-		Assert.assertEquals("http://www.example.org:123/r4", baseUrl);
+		Assert.assertEquals("http://www.example.org:123/reference-server/r4", baseUrl);
 	}
 
 }

--- a/src/test/java/org/mitre/fhir/authorization/TestFhirReferenceServerUtils.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestFhirReferenceServerUtils.java
@@ -23,6 +23,34 @@ public class TestFhirReferenceServerUtils {
 	}
 	
 	@Test
+	public void testGetServerBaseUrlWithHttpDefaultPort()
+	{
+		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setScheme("http");
+		mockHttpServletRequest.setServerName("www.example.org");
+		mockHttpServletRequest.setServerPort(80);
+		mockHttpServletRequest.setRequestURI("/.well-known/smart-configuration");
+		
+		String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockHttpServletRequest);
+		Assert.assertEquals("http://www.example.org/reference-server", baseUrl);
+	}
+	
+	@Test
+	public void testGetServerBaseUrlWithHttpsDefaultPort()
+	{
+		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setScheme("https");
+		mockHttpServletRequest.setServerName("www.example.org");
+		mockHttpServletRequest.setServerPort(443);
+		mockHttpServletRequest.setRequestURI("/.well-known/smart-configuration");
+		
+		String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockHttpServletRequest);
+		Assert.assertEquals("https://www.example.org/reference-server", baseUrl);
+	}
+	
+	@Test
 	public void testGetFhirServerBaseUrl()
 	{
 		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();

--- a/src/test/java/org/mitre/fhir/authorization/TestWellKnownEndpoint.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestWellKnownEndpoint.java
@@ -39,10 +39,10 @@ public class TestWellKnownEndpoint {
 		JsonNode jsonNode = mapper.readTree(jSONString);
 
 		String authorizationEndpoint = jsonNode.get("authorization_endpoint").asText();
-		Assert.assertEquals("http://www.example.org:123/oauth/authorization", authorizationEndpoint);
+		Assert.assertEquals("http://www.example.org:123/reference-server/oauth/authorization", authorizationEndpoint);
 
 		String tokenEndpoint = jsonNode.get("token_endpoint").asText();
-		Assert.assertEquals("http://www.example.org:123/oauth/token", tokenEndpoint);
+		Assert.assertEquals("http://www.example.org:123/reference-server/oauth/token", tokenEndpoint);
 	}
 	
 	@Test 


### PR DESCRIPTION
Changed the root url for the fhir reference server to <base>/reference-server , so now each servlet is under the url reference-server