### PR TITLE
Server now checks the aud and launch params on the authorization page

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/ServerConformanceWithAuthorizationProvider.java
+++ b/src/main/java/org/mitre/fhir/authorization/ServerConformanceWithAuthorizationProvider.java
@@ -24,8 +24,7 @@ public class ServerConformanceWithAuthorizationProvider extends JpaConformancePr
   public static final String AUTHORIZE_EXTENSION_URL = "authorize";
   private static final String OAUTH_URL = "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris";
   private static final String TOKEN_EXTENSION_VALUE_URI = "/oauth/token";
-  //private static final String AUTHORIZE_EXTENSION_VALUE_URI = "/oauth/authorization";
-  private static final String AUTHORIZE_EXTENSION_VALUE_URI = "/oauth/patient-picker";
+  private static final String AUTHORIZE_EXTENSION_VALUE_URI = "/oauth/authorization";
 
 
   private static final String LOCATION_RESOURCE_TYPE = "Location";

--- a/src/main/webapp/WEB-INF/templates/authorization.html
+++ b/src/main/webapp/WEB-INF/templates/authorization.html
@@ -11,16 +11,18 @@
 </head>
 <body>
 
-    <div>Please select which scopes you would like to authorize:</div>
+    <div id="pageContent">
+        <div>Please select which scopes you would like to authorize:</div>
 
-    <br>
+        <br>
 
-    <div id="scopes"></div>
+        <div id="scopes"></div>
 
-    <br>
+        <br>
 
-    <button id="submit" type="button">Authorize</button>
-
+        <button id="submit" type="button">Authorize</button>
+    </div>
+    
     <script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
     <script src="js/lib/DataTables-1.10.20/js/jquery.dataTables.min.js"></script>
     <script src="js/authorize.js"></script>

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -10,17 +10,52 @@ window.mitre.fhirreferenceserver.authorize = {
         //static code that the HAPI interceptor will look for to return token
         let urlParams = new URLSearchParams(window.location.search);
 
-        let state = urlParams.get('state') || '';
+        let aud = urlParams.get('aud');
+
+        const expectedAud = window.location.origin + "/reference-server/r4"
+
+        if (aud !== expectedAud)
+        {
+            alert("Audience " + aud + " is invalid"); 
+            $("#pageContent").hide();
+            return;
+        }
+
+        if (urlParams.has('launch'))
+        {
+            let launch = urlParams.get('launch');
+
+            const expectedLaunch = "123";
+
+            //if launch is provided
+            if (launch !== expectedLaunch)
+            {
+                alert("Launch " + launch + " is invalid"); 
+                $("#pageContent").hide();
+                return;
+            }
+        }
 
         let clientId = urlParams.get('client_id') || '';
+
+        //check for a patient id, if no one exists redirect to patient picker
+        if (!urlParams.has('patient_id'))
+        {
+            let this_uri = window.location;
+            let this_url_encoded = encodeURIComponent(this_uri);
+            let redirect = "../oauth/patient-picker?client_id=" + clientId + "&redirect_uri=" + this_url_encoded;  
+            window.location.href = redirect;
+        }
+
+        let state = urlParams.get('state') || '';
+
 
         //static code that the HAPI interceptor will look for to return token
         let sampleCode = "SAMPLE_CODE";
 
-        let scopes = urlParams.get('scopes') || '';
+        let scopes = urlParams.get('scope') || '';
 
         let scopesList = scopes.split(' ');
-        //http://localhost:8080/hapi-fhir-jpaserver/oauth/authorization?response_type=code&client_id=&redirect_uri=http%3A%2F%2Flocalhost%3A4567%2Finferno%2Foauth2%2Fstatic%2Fredirect&scope=launch%2Fpatient+patient%2F%2A.read+openid+fhirUser+offline_access&state=ddc2657d-7146-418b-8b4e-64e3f8e92eb0&aud=http%3A%2F%2Flocalhost%3A8080%2Fhapi-fhir-jpaserver%2Ffhir
 
         //load scopes
         let checkBoxesHtml = '';

--- a/src/main/webapp/js/patient-picker.js
+++ b/src/main/webapp/js/patient-picker.js
@@ -11,18 +11,9 @@ window.mitre.fhirreferenceserver.patientPicker = {
         //static code that the HAPI interceptor will look for to return token
         let urlParams = new URLSearchParams(window.location.search);
 
-        let state = urlParams.get('state') || '';
-
-        let clientId = urlParams.get('client_id') || '';
-
-        //static code that the HAPI interceptor will look for to return token
-        let sampleCode = "SAMPLE_CODE";
-
-        let scopes = urlParams.get('scope') || '';
-        // base64 encoding that is escaped so it can be used in a url
-        let base64URLEncodedScopes = btoa(scopes);
-
         let redirectUri = urlParams.get('redirect_uri');
+
+        let clientId = urlParams.get('client_id');
 
         //http://localhost:8080/hapi-fhir-jpaserver/oauth/authorization?response_type=code&client_id=&redirect_uri=http%3A%2F%2Flocalhost%3A4567%2Finferno%2Foauth2%2Fstatic%2Fredirect&scope=launch%2Fpatient+patient%2F%2A.read+openid+fhirUser+offline_access&state=ddc2657d-7146-418b-8b4e-64e3f8e92eb0&aud=http%3A%2F%2Flocalhost%3A8080%2Fhapi-fhir-jpaserver%2Ffhir
 
@@ -56,10 +47,17 @@ window.mitre.fhirreferenceserver.patientPicker = {
                 ]).draw(false);
 
                 $('#' + buttonId).click(function () {
-                    let uriEncodedScopes = encodeURI(scopes);
-                    let uriEncodedRedirectUri = encodeURI(redirectUri);
-                    let redirect = "../oauth/authorization" + '?state=' + state + '&client_id=' + clientId + '&scopes=' + uriEncodedScopes + '&redirect_uri=' + uriEncodedRedirectUri + '&patient_id=' + patientId;
+                    
+
+                    //redirectUrlParams.append("patient_id", patientId );
+                    //let redirect = "../oauth/authorization?" + urlParams.toString(); 
+
+                    let redirect = redirectUri + "&patient_id=" + patientId;
+
                     window.location.href = redirect;
+
+
+
                 });
             }
 

--- a/src/test/java/org/mitre/fhir/wellknown/TestWellKnownEndpoint.java
+++ b/src/test/java/org/mitre/fhir/wellknown/TestWellKnownEndpoint.java
@@ -37,8 +37,7 @@ public class TestWellKnownEndpoint {
     JsonNode jsonNode = mapper.readTree(jSONString);
 
     String authorizationEndpoint = jsonNode.get("authorization_endpoint").asText();
-    //Assert.assertEquals("http://www.example.org:123/reference-server/oauth/authorization", authorizationEndpoint);
-    Assert.assertEquals("http://www.example.org:123/reference-server/oauth/patient-picker", authorizationEndpoint);
+    Assert.assertEquals("http://www.example.org:123/reference-server/oauth/authorization", authorizationEndpoint);
 
 
     String tokenEndpoint = jsonNode.get("token_endpoint").asText();


### PR DESCRIPTION
Updated support for checking the aud and launch params.

The reference server should now pass the SMART App Launch Error: Invalid AUD Parameter and SMART App Launch Error: Invalid Launch Parameter in the Other tests (see branch `negative-launch-tests`  in inferno-program)

Also updated authorization page to be authorization which will redirect to the patient picker if no patient_id in the url params