### PR TITLE
updated refresh token to contain scope instead of the token itself

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -134,7 +134,7 @@ public class AuthorizationController {
         patientId = new String(Base64.getDecoder().decode(encodedPatientId));
       }
 
-      if ((code != null && FhirReferenceServerUtils.SAMPLE_CODE.equals(actualCodeOrRefreshToken))) {
+      if (FhirReferenceServerUtils.SAMPLE_CODE.equals(actualCodeOrRefreshToken)) {
         return generateBearerTokenResponse(request, clientId, scopes, patientId);
       }
 

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -117,8 +117,7 @@ public class AuthorizationController {
     if (code != null) {
       fullCodeString = code;
 
-
-      // the provided code is actualcode.scopes
+      // the provided code is in the format <ACTUAL_CODE>.<SCOPES>
       String[] fullCode = fullCodeString.split("\\.");
 
       String actualCodeOrRefreshToken = fullCode[0];
@@ -152,8 +151,6 @@ public class AuthorizationController {
             "Refresh Token " + refreshTokenValue + " was not found");
       }
     }
-
-
 
     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid code");
   }
@@ -214,7 +211,6 @@ public class AuthorizationController {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No patients found");
     }
 
-    // get their id
     List<String> scopesList = Arrays.asList(scopes.split(" "));
 
     if (scopesList.contains("launch") || scopesList.contains("launch/patient")) {

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -210,7 +210,7 @@ public class AuthorizationController {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No patients found");
     }
 
-    List<String> scopesList = Arrays.asList(scopes.split(" "));
+    List<String> scopesList = Arrays.asList(scopes.split(" +"));
 
     if (scopesList.contains("launch") || scopesList.contains("launch/patient")) {
       tokenJson.put("patient", patientId);

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -116,7 +116,6 @@ public class AuthorizationController {
 
     if (code != null) {
       fullCodeString = code;
-
       // the provided code is in the format <ACTUAL_CODE>.<SCOPES>
       String[] fullCode = fullCodeString.split("\\.");
 

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -141,8 +141,7 @@ public class AuthorizationController {
     } else if (refreshTokenValue != null) {
 
       try {
-        if (refreshTokenValue != null
-            && TokenManager.getInstance().authenticateRefreshToken(refreshTokenValue)) {
+        if (TokenManager.getInstance().authenticateRefreshToken(refreshTokenValue)) {
           Token refreshToken = TokenManager.getInstance().getRefreshToken(refreshTokenValue);
           patientId = refreshToken.getPatientId();
           String refreshTokenScopes = refreshToken.getScopesString();

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -151,8 +151,6 @@ public class AuthorizationController {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
             "Refresh Token " + refreshTokenValue + " was not found");
       }
-    } else {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid code");
     }
 
 

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -139,7 +139,6 @@ public class AuthorizationController {
       }
 
     } else if (refreshTokenValue != null) {
-      // fullCodeString = refreshToken;
 
       try {
         if (refreshTokenValue != null
@@ -192,9 +191,6 @@ public class AuthorizationController {
 
     JSONObject tokenJson = new JSONObject();
 
-
-    // String encodedScopes = Base64.getEncoder().encodeToString(scopes.getBytes());
-
     TokenManager tokenManager = TokenManager.getInstance();
     Token token = tokenManager.createToken(scopes);
 
@@ -203,13 +199,11 @@ public class AuthorizationController {
       Token refreshToken = tokenManager.getCorrespondingRefreshToken(token.getTokenValue());
       refreshToken.setPatientId(patientId);
       refreshTokenValue = refreshToken.getTokenValue();
-
-      // FhirReferenceServerUtils.createCode(refreshToken.getTokenValue(), scopes, patientId);
     } catch (Exception exception) {
       throw new BearerTokenException(exception);
     }
 
-    String accessToken = token.getTokenValue(); // + "." + encodedScopes;
+    String accessToken = token.getTokenValue();
 
     tokenJson.put("access_token", accessToken);
     tokenJson.put("token_type", "bearer");
@@ -224,7 +218,6 @@ public class AuthorizationController {
     }
 
     // get their id
-    // String patientId = patient.getIdElement().getIdPart();
     List<String> scopesList = Arrays.asList(scopes.split(" "));
 
     if (scopesList.contains("launch") || scopesList.contains("launch/patient")) {

--- a/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
+++ b/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
@@ -45,7 +45,6 @@ public class FakeOauth2AuthorizationInterceptorAdaptor extends InterceptorAdapte
       throw new InvalidBearerTokenException(bearerToken);
     }
 
-    // List<String> scopesArray = Arrays.asList(scopes.split(" "));
     List<String> grantedResources = new ArrayList<String>();
 
     for (String currentScope : scopesArray) {

--- a/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
+++ b/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
@@ -3,9 +3,7 @@ package org.mitre.fhir.authorization;
 
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.interceptor.InterceptorAdapter;
-import com.github.dnault.xmlpatch.internal.Log;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -13,7 +11,6 @@ import org.mitre.fhir.authorization.exception.InvalidBearerTokenException;
 import org.mitre.fhir.authorization.exception.InvalidScopesException;
 import org.mitre.fhir.authorization.token.TokenManager;
 import org.mitre.fhir.authorization.token.TokenNotFoundException;
-import org.postgresql.util.Base64;
 
 public class FakeOauth2AuthorizationInterceptorAdaptor extends InterceptorAdapter {
 
@@ -37,23 +34,34 @@ public class FakeOauth2AuthorizationInterceptorAdaptor extends InterceptorAdapte
 
     bearerToken = bearerToken.replaceFirst(BEARER_TOKEN_PREFIX, "");
 
-    String[] splitBearerTokenParts = bearerToken.split("\\.");
+    //String[] splitBearerTokenParts = bearerToken.split("\\.");
 
-    if (splitBearerTokenParts.length != 2) {
+    /*if (splitBearerTokenParts.length != 2) {
       throw new InvalidBearerTokenException(bearerToken);
     }
 
-    String actualBearerToken = splitBearerTokenParts[0];
+    String actualBearerToken = splitBearerTokenParts[0];*/
 
-    if (!isBearerTokenValid(actualBearerToken)) {
+    if (!isBearerTokenValid(bearerToken)) {
       throw new InvalidBearerTokenException(bearerToken);
     }
 
-    String encodedScopes = splitBearerTokenParts[1];
+    //String encodedScopes = splitBearerTokenParts[1];
 
-    String scopes = new String(Base64.decode(encodedScopes));
-
-    List<String> scopesArray = Arrays.asList(scopes.split(" "));
+    //String scopes = new String(Base64.decode(encodedScopes));
+    
+    List<String> scopesArray;
+    try
+    {
+      scopesArray = TokenManager.getInstance().getToken(bearerToken).getScopes();
+    }
+    
+    catch (TokenNotFoundException tokenNotFoundException)
+    {
+      throw new InvalidBearerTokenException(bearerToken);      
+    }
+    
+    //List<String> scopesArray = Arrays.asList(scopes.split(" "));
     List<String> grantedResources = new ArrayList<String>();
 
     for (String currentScope : scopesArray) {

--- a/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
+++ b/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
@@ -34,22 +34,9 @@ public class FakeOauth2AuthorizationInterceptorAdaptor extends InterceptorAdapte
 
     bearerToken = bearerToken.replaceFirst(BEARER_TOKEN_PREFIX, "");
 
-    // String[] splitBearerTokenParts = bearerToken.split("\\.");
-
-    /*
-     * if (splitBearerTokenParts.length != 2) { throw new InvalidBearerTokenException(bearerToken);
-     * }
-     * 
-     * String actualBearerToken = splitBearerTokenParts[0];
-     */
-
     if (!isBearerTokenValid(bearerToken)) {
       throw new InvalidBearerTokenException(bearerToken);
     }
-
-    // String encodedScopes = splitBearerTokenParts[1];
-
-    // String scopes = new String(Base64.decode(encodedScopes));
 
     List<String> scopesArray;
     try {

--- a/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
+++ b/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
@@ -34,34 +34,31 @@ public class FakeOauth2AuthorizationInterceptorAdaptor extends InterceptorAdapte
 
     bearerToken = bearerToken.replaceFirst(BEARER_TOKEN_PREFIX, "");
 
-    //String[] splitBearerTokenParts = bearerToken.split("\\.");
+    // String[] splitBearerTokenParts = bearerToken.split("\\.");
 
-    /*if (splitBearerTokenParts.length != 2) {
-      throw new InvalidBearerTokenException(bearerToken);
-    }
-
-    String actualBearerToken = splitBearerTokenParts[0];*/
+    /*
+     * if (splitBearerTokenParts.length != 2) { throw new InvalidBearerTokenException(bearerToken);
+     * }
+     * 
+     * String actualBearerToken = splitBearerTokenParts[0];
+     */
 
     if (!isBearerTokenValid(bearerToken)) {
       throw new InvalidBearerTokenException(bearerToken);
     }
 
-    //String encodedScopes = splitBearerTokenParts[1];
+    // String encodedScopes = splitBearerTokenParts[1];
 
-    //String scopes = new String(Base64.decode(encodedScopes));
-    
+    // String scopes = new String(Base64.decode(encodedScopes));
+
     List<String> scopesArray;
-    try
-    {
+    try {
       scopesArray = TokenManager.getInstance().getToken(bearerToken).getScopes();
+    } catch (TokenNotFoundException tokenNotFoundException) {
+      throw new InvalidBearerTokenException(bearerToken);
     }
-    
-    catch (TokenNotFoundException tokenNotFoundException)
-    {
-      throw new InvalidBearerTokenException(bearerToken);      
-    }
-    
-    //List<String> scopesArray = Arrays.asList(scopes.split(" "));
+
+    // List<String> scopesArray = Arrays.asList(scopes.split(" "));
     List<String> grantedResources = new ArrayList<String>();
 
     for (String currentScope : scopesArray) {

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -11,6 +11,10 @@ public class Token {
 
   private String tokenValue;
 
+  /**
+   * Token constructor.
+   * @param scopes scopes this token is authorized to access
+   */
   public Token(List<String> scopes) {
     UUID uuid = UUID.randomUUID();
     this.tokenValue = uuid.toString();
@@ -28,33 +32,32 @@ public class Token {
   public String getTokenValue() {
     return tokenValue;
   }
-  
-  public List<String> getScopes()
-  {
+
+  public List<String> getScopes() {
     return scopes;
   }
-  
-  public String getScopesString()
-  {
+
+  /**
+   * Gets the list of scopes as a string.
+   * @return a string of each scope separated by a space
+   */
+  public String getScopesString() {
     String scopesString = "";
-    for (String scope : scopes)
-    {
+    for (String scope : scopes) {
       scopesString += scope + " ";
     }
-    
+
     scopesString = scopesString.strip();
-    
+
     return scopesString;
-    
+
   }
-  
-  public void setPatientId(String patientId)
-  {
+
+  public void setPatientId(String patientId) {
     this.patientId = patientId;
   }
-  
-  public String getPatientId()
-  {
+
+  public String getPatientId() {
     return patientId;
   }
 

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -42,16 +42,12 @@ public class Token {
    * @return a string of each scope separated by a space
    */
   public String getScopesString() {
-    String scopesString = "";
+    StringBuilder scopesString = new StringBuilder();
     for (String scope : scopes) {
-      scopesString += scope + " ";
+      scopesString.append(scope).append(" ");
     }
 
-    scopesString = scopesString.strip();
-
-    return scopesString;
-
-  }
+    return scopesString.toString().strip();
 
   public void setPatientId(String patientId) {
     this.patientId = patientId;

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -48,6 +48,7 @@ public class Token {
     }
 
     return scopesString.toString().strip();
+  }
 
   public void setPatientId(String patientId) {
     this.patientId = patientId;

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -1,16 +1,20 @@
 package org.mitre.fhir.authorization.token;
 
+import java.util.List;
 import java.util.UUID;
 
 public class Token {
 
   private boolean active = true;
+  private List<String> scopes;
+  private String patientId;
 
   private String tokenValue;
 
-  public Token() {
+  public Token(List<String> scopes) {
     UUID uuid = UUID.randomUUID();
     this.tokenValue = uuid.toString();
+    this.scopes = scopes;
   }
 
   public void revokeToken() {
@@ -23,6 +27,35 @@ public class Token {
 
   public String getTokenValue() {
     return tokenValue;
+  }
+  
+  public List<String> getScopes()
+  {
+    return scopes;
+  }
+  
+  public String getScopesString()
+  {
+    String scopesString = "";
+    for (String scope : scopes)
+    {
+      scopesString += scope + " ";
+    }
+    
+    scopesString = scopesString.strip();
+    
+    return scopesString;
+    
+  }
+  
+  public void setPatientId(String patientId)
+  {
+    this.patientId = patientId;
+  }
+  
+  public String getPatientId()
+  {
+    return patientId;
   }
 
 }

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 public class Token {
 
   private boolean active = true;
-  private List<String> scopes;
+  private final List<String> scopes;
   private String patientId;
 
   private String tokenValue;

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -9,7 +9,7 @@ public class Token {
   private final List<String> scopes;
   private String patientId;
 
-  private String tokenValue;
+  private final String tokenValue;
 
   /**
    * Token constructor.

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -1,8 +1,11 @@
 
 package org.mitre.fhir.authorization.token;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.mitre.fhir.utils.FhirReferenceServerUtils;
 
 public class TokenManager {
 
@@ -30,21 +33,52 @@ public class TokenManager {
 
     return instance;
   }
+  
+  /**
+   * Creates a token.
+   * 
+   * @return the created token
+   */
+  public Token createToken(String scopesString) {
+    String[] splitString = scopesString != null ? scopesString.split(" ") : new String[0];
+    List<String> scopes = Arrays.asList(splitString);
+    return createToken(scopes);
+  }
 
   /**
    * Creates a token.
    * 
    * @return the created token
    */
-  public Token createToken() {
-    Token token = new Token();
+  public Token createToken(List<String> scopes) {
+    Token token = new Token(scopes);
     tokenMap.put(token.getTokenValue(), token);
 
-    Token refreshToken = new Token();
+    Token refreshToken = new Token(scopes);
     tokenToCorrespondingRefreshToken.put(token.getTokenValue(), refreshToken.getTokenValue());
     refreshTokenMap.put(refreshToken.getTokenValue(), refreshToken);
 
     return token;
+  }
+  
+  public Token getToken(String tokenValue) throws TokenNotFoundException {
+    // confirm we were passed a valid token value
+    if (!tokenMap.containsKey(tokenValue)) {
+      throw new TokenNotFoundException(tokenValue);
+    } 
+    
+    return tokenMap.get(tokenValue);
+  }
+  
+  public Token getRefreshToken(String refreshTokenValue) throws TokenNotFoundException
+  {
+ // confirm we were passed a valid token value
+    if (!refreshTokenMap.containsKey(refreshTokenValue)) {
+      throw new TokenNotFoundException(refreshTokenValue);
+    } 
+    
+    return refreshTokenMap.get(refreshTokenValue);
+
   }
 
   /**
@@ -143,7 +177,7 @@ public class TokenManager {
   public Token getServerToken() {
 
     if (serverToken == null) {
-      serverToken = createToken();
+      serverToken = createToken(FhirReferenceServerUtils.DEFAULT_SCOPE);
     }
 
     return serverToken;

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -61,6 +61,13 @@ public class TokenManager {
     return token;
   }
   
+  /**
+   * Gets a Token based on the token value.
+   * 
+   * @param tokenValue the token's key value
+   * @return the corresponding token
+   * @throws TokenNotFoundException if no token with tokenValue exists
+   */
   public Token getToken(String tokenValue) throws TokenNotFoundException {
     // confirm we were passed a valid token value
     if (!tokenMap.containsKey(tokenValue)) {
@@ -70,9 +77,14 @@ public class TokenManager {
     return tokenMap.get(tokenValue);
   }
   
-  public Token getRefreshToken(String refreshTokenValue) throws TokenNotFoundException
-  {
- // confirm we were passed a valid token value
+  /**
+   * Get the corresponding Token for a refresh token.
+   * @param refreshTokenValue the refresh token's key value
+   * @return the corresponding refresh token
+   * @throws TokenNotFoundException if no refresh token with refreshTokenValue exists
+   */
+  public Token getRefreshToken(String refreshTokenValue) throws TokenNotFoundException {
+    // confirm we were passed a valid token value
     if (!refreshTokenMap.containsKey(refreshTokenValue)) {
       throw new TokenNotFoundException(refreshTokenValue);
     } 

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -123,16 +123,14 @@ public class TokenManager {
    * @throws InactiveTokenException the token has already been revoked.
    */
   public void revokeToken(String tokenValue) throws TokenNotFoundException, InactiveTokenException {
-    
-    String truncatedToken = tokenValue.split("\\.")[0]; //remove any scopes
-    
-    Token token = tokenMap.get(truncatedToken);
+        
+    Token token = tokenMap.get(tokenValue);
 
     if (token != null) {
       if (token.isActive()) {
         token.revokeToken();
         // revoke the refresh token
-        Token refreshToken = getCorrespondingRefreshToken(truncatedToken);
+        Token refreshToken = getCorrespondingRefreshToken(tokenValue);
         refreshToken.revokeToken();
       } else {
         throw new InactiveTokenException(token);

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -40,7 +40,7 @@ public class TokenManager {
    * @return the created token
    */
   public Token createToken(String scopesString) {
-    String[] splitString = scopesString != null ? scopesString.split(" ") : new String[0];
+    String[] splitString = scopesString != null ? scopesString.split(" +") : new String[0];
     List<String> scopes = Arrays.asList(splitString);
     return createToken(scopes);
   }

--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -77,10 +77,8 @@ public class FhirReferenceServerUtils {
    * @param scopes the selected fhir scopes
    * @return
    */
-  public static String createAuthorizationHeaderValue(String accessToken, String scopes) {
-    String encodedScopes = Base64.getEncoder().encodeToString(scopes.getBytes());
-    return BEARER_TOKEN_PREFIX + " " + accessToken + "." + encodedScopes;
-
+  public static String createAuthorizationHeaderValue(String accessToken) {
+    return BEARER_TOKEN_PREFIX + " " + accessToken;
   }
 
 }

--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -74,7 +74,6 @@ public class FhirReferenceServerUtils {
    * Create the Authorizartion Header value.
    * 
    * @param accessToken the access token value
-   * @param scopes the selected fhir scopes
    * @return
    */
   public static String createAuthorizationHeaderValue(String accessToken) {

--- a/src/main/java/org/mitre/fhir/utils/FhirUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirUtils.java
@@ -57,8 +57,7 @@ public class FhirUtils {
     Bundle bundle = client.search().forResource(resourceName).returnBundle(Bundle.class).count(1000)
         .cacheControl(cacheControlDirective)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue(),
-                FhirReferenceServerUtils.DEFAULT_SCOPE))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
         .execute();
 
     return bundle;

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -43,7 +43,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
@@ -48,8 +48,7 @@ public class TestAuthorizationWithNoData {
 
     IIdType patientId = ourClient.create().resource(pt)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue(),
-                FhirReferenceServerUtils.DEFAULT_SCOPE))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute().getId();
 
     AuthorizationController authorizationController = new AuthorizationController();
@@ -67,8 +66,7 @@ public class TestAuthorizationWithNoData {
 
     ourClient.delete().resourceById(patientId)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue(),
-                FhirReferenceServerUtils.DEFAULT_SCOPE))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute();
 
   }
@@ -81,8 +79,7 @@ public class TestAuthorizationWithNoData {
     Encounter encounter = new Encounter();
     IIdType encounterId = ourClient.create().resource(encounter)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue(),
-                FhirReferenceServerUtils.DEFAULT_SCOPE))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute().getId();
 
     AuthorizationController authorizationController = new AuthorizationController();
@@ -100,8 +97,7 @@ public class TestAuthorizationWithNoData {
 
     ourClient.delete().resourceById(encounterId)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue(),
-                FhirReferenceServerUtils.DEFAULT_SCOPE))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute();
 
   }

--- a/src/test/java/org/mitre/fhir/authorization/token/TestTokenManager.java
+++ b/src/test/java/org/mitre/fhir/authorization/token/TestTokenManager.java
@@ -25,7 +25,7 @@ public class TestTokenManager {
   @Test
   public void testCreateToken() throws TokenNotFoundException {
     TokenManager tokenManager = TokenManager.getInstance();
-    Token token = tokenManager.createToken();
+    Token token = tokenManager.createToken("");
 
     Assert.assertTrue(tokenManager.authenticateToken(token.getTokenValue()));
 
@@ -52,7 +52,7 @@ public class TestTokenManager {
   @Test
   public void testRevokeToken() throws TokenNotFoundException, InactiveTokenException {
     TokenManager tokenManager = TokenManager.getInstance();
-    Token token = tokenManager.createToken();
+    Token token = tokenManager.createToken("");
 
     Token refreshToken = tokenManager.getCorrespondingRefreshToken(token.getTokenValue());
 
@@ -79,7 +79,7 @@ public class TestTokenManager {
   @Test(expected = InactiveTokenException.class)
   public void testRevokingInactiveToken() throws TokenNotFoundException, InactiveTokenException {
     TokenManager tokenManager = TokenManager.getInstance();
-    Token token = tokenManager.createToken();
+    Token token = tokenManager.createToken("");
 
     tokenManager.revokeToken(token.getTokenValue());
     // token should be revoked, so inactive

--- a/src/test/java/org/mitre/fhir/authorization/token/TestTokenManager.java
+++ b/src/test/java/org/mitre/fhir/authorization/token/TestTokenManager.java
@@ -59,12 +59,10 @@ public class TestTokenManager {
     Assert.assertTrue(tokenManager.authenticateToken(token.getTokenValue()));
     Assert.assertTrue(tokenManager.authenticateRefreshToken(refreshToken.getTokenValue()));
 
-    tokenManager.revokeToken(token.getTokenValue() + ".SCOPES");
+    tokenManager.revokeToken(token.getTokenValue());
 
-    Assert.assertFalse(tokenManager.authenticateToken(token.getTokenValue())); // should fail
-                                                                               // because token was
-                                                                               // revoked
-
+    //should fail because token was revoked
+    Assert.assertFalse(tokenManager.authenticateToken(token.getTokenValue())); 
     Assert.assertFalse(tokenManager.authenticateRefreshToken(refreshToken.getTokenValue()));
   }
 

--- a/src/test/java/org/mitre/fhir/utils/TestUtils.java
+++ b/src/test/java/org/mitre/fhir/utils/TestUtils.java
@@ -58,8 +58,7 @@ public class TestUtils {
       System.out.println("Deleting Patient " + patient.getIdElement().getIdPart());
       ourClient.delete().resource(patient)
           .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-              TestUtils.getAuthorizationHeaderBearerValue(token.getTokenValue(),
-                  FhirReferenceServerUtils.DEFAULT_SCOPE))
+              TestUtils.getAuthorizationHeaderBearerValue(token.getTokenValue()))
           .execute();
     }
 
@@ -75,15 +74,13 @@ public class TestUtils {
       System.out.println("Deleting Encounter " + encounter.getIdElement().getIdPart());
       ourClient.delete().resource(encounter)
           .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-              TestUtils.getAuthorizationHeaderBearerValue(token.getTokenValue(),
-                  FhirReferenceServerUtils.DEFAULT_SCOPE))
+              TestUtils.getAuthorizationHeaderBearerValue(token.getTokenValue()))
           .execute();
     }
   }
 
-  public static String getAuthorizationHeaderBearerValue(String accessToken, String scopes) {
-    String encodedScopes = Base64.getEncoder().encodeToString(scopes.getBytes());
-    return BEARER_TOKEN_PREFIX + " " + accessToken + "." + encodedScopes;
+  public static String getAuthorizationHeaderBearerValue(String accessToken) {
+    return BEARER_TOKEN_PREFIX + " " + accessToken;
   }
 
 }


### PR DESCRIPTION
Removed the encoded scopes from the bearer token, and instead store that information on the server.  This means that someone with the token cannot change the scopes by understanding how the token is structured and the token is simpler in general.  Current this change is only for the bearer token, and not the code (which is not stored on the reference server at the moment, but will be updated in https://oncprojectracking.healthit.gov/support/browse/FI-939