### PR TITLE
added support for specifying a custom port in an env variable

### DIFF
--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -20,6 +20,8 @@ public class FhirReferenceServerUtils {
 
   public static final String DEFAULT_SCOPE = "launch/patient patient/*";
 
+  public static final String CUSTOM_PORT_KEY = "CUSTOM_PORT";
+  
   private static final String HTTP = "http";
   private static final String HTTPS = "https";
   private static final int HTTP_DEFAULT_PORT = 80;
@@ -36,9 +38,19 @@ public class FhirReferenceServerUtils {
     int portNumber = request.getServerPort();
     String port = ":" + portNumber;
 
+    String customPortString = System.getenv(CUSTOM_PORT_KEY);
+
+    int customPortNumber = -1;
+    try {
+      customPortNumber = Integer.parseInt(customPortString);
+    } catch (NumberFormatException numberFormatException) {
+
+    }
+
     // if default port, remove the port
     if ((HTTP.equals(scheme) && portNumber == HTTP_DEFAULT_PORT)
-        || (HTTPS.equals(scheme) && portNumber == HTTPS_DEFAULT_PORT)) {
+        || (HTTPS.equals(scheme) && portNumber == HTTPS_DEFAULT_PORT)
+        || portNumber == customPortNumber) {
       port = "";
     }
 

--- a/src/test/java/org/mitre/fhir/utils/TestFhirReferenceServerUtils.java
+++ b/src/test/java/org/mitre/fhir/utils/TestFhirReferenceServerUtils.java
@@ -1,8 +1,8 @@
 package org.mitre.fhir.utils;
 
+import com.github.stefanbirkner.systemlambda.SystemLambda;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mitre.fhir.utils.FhirReferenceServerUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 public class TestFhirReferenceServerUtils {
@@ -18,6 +18,40 @@ public class TestFhirReferenceServerUtils {
 
     String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockHttpServletRequest);
     Assert.assertEquals("http://www.example.org:123/reference-server", baseUrl);
+
+  }
+
+  @Test
+  public void testGetServerBaseUrlWithEnvVar() throws Exception {
+    SystemLambda.withEnvironmentVariable("CUSTOM_PORT", "8443").execute(() -> {
+      MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+      mockHttpServletRequest.setScheme("http");
+      mockHttpServletRequest.setServerName("www.example.org");
+      mockHttpServletRequest.setServerPort(8443);
+      mockHttpServletRequest.setRequestURI("/.well-known/smart-configuration");
+
+      String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockHttpServletRequest);
+      Assert.assertEquals("http://www.example.org/reference-server", baseUrl);
+
+    });
+
+  }
+  
+  @Test
+  public void testGetServerBaseUrlWithEnvVarInvalidValue() throws Exception {
+    SystemLambda.withEnvironmentVariable("CUSTOM_PORT", "TEST").execute(() -> {
+      MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+      mockHttpServletRequest.setScheme("http");
+      mockHttpServletRequest.setServerName("www.example.org");
+      mockHttpServletRequest.setServerPort(8443);
+      mockHttpServletRequest.setRequestURI("/.well-known/smart-configuration");
+
+      String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockHttpServletRequest);
+      Assert.assertEquals("http://www.example.org:8443/reference-server", baseUrl);
+
+    });
 
   }
 


### PR DESCRIPTION
This is due to the nginx issue where for some reason the port is on 8443 instead of 443.  

To test this, build this version of the reference server, and run it in site overlay with branch https://github.com/onc-healthit/inferno-site-overlay/tree/custom-port-quick-fix

Go to 
https://localhost/reference-server/r4/.well-known/smart-configuration

and confirm that token_endpoint does not have the port in it