### PR TITLE
Fi 1093 change skip auth to specifiy token value

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ To use as a confidential client, use `SAMPLE_CONFIDENTIAL_CLIENT_ID` as the clie
 
 To launch an app from the EHR go to `reference-server/app/app-launch`
 
-## Run without an Authentication Token
+## Custom Authentication Token
 
-If you would like to execute requests without a valid bearer token, you can set the environment variable `SKIP_TOKEN_AUTHENTICATION` to `true` 
+If you would like to execute requests without going through the process to get a token, you can set the environment variable `CUSTOM_BEARER_TOKEN` to a value of your choice. 
 
 ## Revoking a token
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - '8080:8080'
     environment:
       - POSTGRES_HOST=db
-      - SKIP_TOKEN_AUTHENTICATION=true
+      - CUSTOM_BEARER_TOKEN=SAMPLE_TOKEN
     networks:
       - fhirnet
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
 			<version>2.15.1</version>
 		</dependency>
 		
+		<!-- For testing with custom env variables -->
 		<dependency>
 		    <groupId>com.github.stefanbirkner</groupId>
 		    <artifactId>system-lambda</artifactId>

--- a/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
+++ b/src/main/java/org/mitre/fhir/authorization/FakeOauth2AuthorizationInterceptorAdaptor.java
@@ -29,35 +29,28 @@ public class FakeOauth2AuthorizationInterceptorAdaptor extends InterceptorAdapte
     List<String> scopesArray;
     TokenManager tokenManager = TokenManager.getInstance();
 
-    if (tokenManager.shouldSkipTokenAuthentication()) {
-      scopesArray = new ArrayList<>();
-      scopesArray.add("system/*");
+    String bearerToken = requestDetails.getHeader("Authorization");
 
-    } else {
+    if (bearerToken == null) {
+      throw new InvalidBearerTokenException(bearerToken);
+    }
 
-      String bearerToken = requestDetails.getHeader("Authorization");
+    bearerToken = bearerToken.replaceFirst(BEARER_TOKEN_PREFIX, "");
 
-      if (bearerToken == null) {
-        throw new InvalidBearerTokenException(bearerToken);
-      }
+    try {
 
-      bearerToken = bearerToken.replaceFirst(BEARER_TOKEN_PREFIX, "");
-
-      try {
-
-        tokenManager.authenticateBearerToken(bearerToken);
+      tokenManager.authenticateBearerToken(bearerToken);
 
 
-      } catch (TokenNotFoundException e) {
-        throw new InvalidBearerTokenException(bearerToken);
-      }
+    } catch (TokenNotFoundException e) {
+      throw new InvalidBearerTokenException(bearerToken);
+    }
 
-      try {
-        scopesArray = tokenManager.getToken(bearerToken).getScopes();
-      } catch (TokenNotFoundException tokenNotFoundException) {
-        throw new InvalidBearerTokenException(bearerToken);
+    try {
+      scopesArray = tokenManager.getToken(bearerToken).getScopes();
+    } catch (TokenNotFoundException tokenNotFoundException) {
+      throw new InvalidBearerTokenException(bearerToken);
 
-      }
     }
 
     List<String> grantedResources = new ArrayList<String>();

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -10,19 +10,19 @@ public class Token {
   private String patientId;
 
   private final String tokenValue;
-  
+
   /**
    * Token constructor.
+   * 
    * @param scopes scopes this token is authorized to access
    */
   public Token(List<String> scopes) {
     this(UUID.randomUUID().toString(), scopes);
   }
-  
-  public Token(String tokenValue, List<String> scopes)
-  {
+
+  public Token(String tokenValue, List<String> scopes) {
     this.tokenValue = tokenValue;
-    this.scopes = scopes;    
+    this.scopes = scopes;
   }
 
   public void revokeToken() {
@@ -43,6 +43,7 @@ public class Token {
 
   /**
    * Gets the list of scopes as a string.
+   * 
    * @return a string of each scope separated by a space
    */
   public String getScopesString() {

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -10,15 +10,19 @@ public class Token {
   private String patientId;
 
   private final String tokenValue;
-
+  
   /**
    * Token constructor.
    * @param scopes scopes this token is authorized to access
    */
   public Token(List<String> scopes) {
-    UUID uuid = UUID.randomUUID();
-    this.tokenValue = uuid.toString();
-    this.scopes = scopes;
+    this(UUID.randomUUID().toString(), scopes);
+  }
+  
+  public Token(String tokenValue, List<String> scopes)
+  {
+    this.tokenValue = tokenValue;
+    this.scopes = scopes;    
   }
 
   public void revokeToken() {

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -22,16 +22,16 @@ public class TokenManager {
   private Token serverToken;
 
   private TokenManager() {
-    //add default token from settings
+    // add default token from settings
     String customBearerTokenString = System.getenv().get(CUSTOM_BEARER_TOKEN_ENV_KEY);
-    
-    if (customBearerTokenString != null)
-    {
-      Token customBearerToken = new Token(customBearerTokenString, FhirReferenceServerUtils.getScopesListByScopeString(CUSTOM_BEARER_TOKEN_SCOPE_STRING));
+
+    if (customBearerTokenString != null) {
+      Token customBearerToken = new Token(customBearerTokenString,
+          FhirReferenceServerUtils.getScopesListByScopeString(CUSTOM_BEARER_TOKEN_SCOPE_STRING));
       addTokenToTokenMap(customBearerToken);
       createCorrespondingRefreshToken(customBearerToken);
     }
-      
+
   }
 
   /**
@@ -68,15 +68,13 @@ public class TokenManager {
     createCorrespondingRefreshToken(token);
     return token;
   }
-  
-  private void addTokenToTokenMap(Token token)
-  {
+
+  private void addTokenToTokenMap(Token token) {
     tokenMap.put(token.getTokenValue(), token);
   }
-  
-  private void createCorrespondingRefreshToken(Token token)
-  {
-    
+
+  private void createCorrespondingRefreshToken(Token token) {
+
     Token refreshToken = new Token(token.getScopes());
     tokenToCorrespondingRefreshToken.put(token.getTokenValue(), refreshToken.getTokenValue());
     refreshTokenMap.put(refreshToken.getTokenValue(), refreshToken);

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -157,13 +156,6 @@ public class TestAuthorization {
             FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
         .execute();
 
-  }
-
-  @Test
-  public void testInterceptorWithSkipTokenAuthenticationEnvironmentVariable() throws Exception {
-
-    SystemLambda.withEnvironmentVariable("SKIP_TOKEN_AUTHENTICATION", "true")
-        .execute(() -> ourClient.search().forResource("Patient").execute());
   }
 
   @Test(expected = AuthenticationException.class)


### PR DESCRIPTION
Removing the option to Skip Authentication and instead adding a env var to contain a custom bearer token.

To Test, set an env var CUSTOM_BEARER_TOKEN to value and try to enact a request with that bearer token.